### PR TITLE
Fixed email error validation in Login and Forgot Password forms

### DIFF
--- a/ChatApp/src/components/organisms/forgetPassword/index.js
+++ b/ChatApp/src/components/organisms/forgetPassword/index.js
@@ -56,7 +56,7 @@ const ForgotPasswordForm = () => {
         keyboardType="email-address" // Set keyboard type for email input
         autoCapitalize="none" // Disable auto-capitalization for email
         leftIconName="email" // Set the left icon to "email"
-        errorMessage={isEmailValid ? "" : "Invalid email format"} // Show error if email is invalid
+        errorMessage={!isEmailValid && email ? "Invalid email format" : ""} // Show error if email is invalid
         style={{ fontFamily: "cretype-caros" }}
       />
 

--- a/ChatApp/src/components/organisms/loginForm/index.js
+++ b/ChatApp/src/components/organisms/loginForm/index.js
@@ -69,7 +69,7 @@ const LoginForm = () => {
         keyboardType="email-address"
         autoCapitalize="none"
         leftIconName="email"
-        errorMessage={isEmailValid ? "" : "Invalid email format"}
+        errorMessage={!isEmailValid && email ? "Invalid email format" : ""}
       />
 
       {/* Password Input Field */}


### PR DESCRIPTION
Fixed the email validation error in the login and forgot password forms. Previously, the error message "Invalid email format" would display even without user input. Now, the error only appears when there is actual input that doesn't match a valid email format.